### PR TITLE
move fs-extra from devDependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
+    "fs-extra": "^1.0.0",
     "sliced": "^1.0.1"
   },
   "devDependencies": {
     "async": "^1.5.2",
     "chai": "^3.4.1",
     "express": "^4.13.3",
-    "fs-extra": "^1.0.0",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "downloads"
   ],
   "peerDependencies": {
+    "fs-extra": "^1.0.0",
     "nightmare": "^2.5.2"
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "fs-extra": "^1.0.0",
     "sliced": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
fs-extra is used in nightmare-download-manager.js, so it should be in dependencies.

(This broke for me with MODULE_NOT_FOUND when nightmare-download-manager was a dependency of a dependency of my package.)